### PR TITLE
Add platform specifications to Package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Alamofire/Alamofire",
         "state": {
           "branch": null,
-          "revision": "b8995447518fd57af14c88a47f27434a16f60403",
-          "version": "4.5.1"
+          "revision": "ce5be6fbc6f51414c49f56fc8e2b7c99253d9f8e",
+          "version": "4.9.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,14 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.1
 
 import PackageDescription
 
 let package = Package(
     name: "CodableAlamofire",
+    platforms: [
+        .iOS(.v11),
+        .tvOS(.v13),
+        .watchOS(.v6)
+    ],
     products: [
         .library(name: "CodableAlamofire", targets: ["CodableAlamofire"]),
     ],


### PR DESCRIPTION
This PR updates the Package.swift tool version and adds platform information.

This makes it possible to use CodableAlamofire with Alamofire 4.9 using Swift Package Manager.