### PR TITLE
Alamofire 4.x and RxSwift 6 Support

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire"
+github "Alamofire/Alamofire" ~> 4.9.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.8.1"
+github "Alamofire/Alamofire" "4.9.1"

--- a/CodableAlamofire.podspec
+++ b/CodableAlamofire.podspec
@@ -9,14 +9,14 @@
 Pod::Spec.new do |s|
 
   s.name               = "CodableAlamofire"
-  s.version            = "1.1.2"
+  s.version            = "2.0.0"
   s.summary            = "An extension for Alamofire that converts JSON data into Decodable Objects."
   s.homepage           = "https://github.com/Otbivnoe/CodableAlamofire"
   s.license            = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Nikita Ermolenko" => "gnod94@gmail.com" }
   s.social_media_url   = "https://twitter.com/iOtbivnoe"
 
-  s.ios.deployment_target     = '10.0'
+  s.ios.deployment_target     = '9.0'
   s.osx.deployment_target     = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target    = '9.0'

--- a/CodableAlamofire.podspec
+++ b/CodableAlamofire.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.author             = { "Nikita Ermolenko" => "gnod94@gmail.com" }
   s.social_media_url   = "https://twitter.com/iOtbivnoe"
 
-  s.ios.deployment_target     = '8.0'
+  s.ios.deployment_target     = '10.0'
   s.osx.deployment_target     = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target    = '9.0'

--- a/CodableAlamofire.podspec
+++ b/CodableAlamofire.podspec
@@ -26,6 +26,6 @@ Pod::Spec.new do |s|
   s.swift_versions = ['4.0', '5.0', '5.1']
 
   s.requires_arc = true
-  s.dependency 'Alamofire', '~> 4.0'
+  s.dependency 'Alamofire', '~> 4.9'
 
 end


### PR DESCRIPTION
Moving to Alamofire 5.x isn't possible for us at the moment but we would like to be one RxSwift 6.2 for other reasons.

This is branched off the last Alamofire 4.x release as far as I can tell but github won't accept a pr against it for some reason.

I'll appreciate if this is no longer part of this repo and maintain my own fork until we can get Alamofire upgraded.